### PR TITLE
Fix typo in confirmed fixed printers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ T:23.84 /0.00 B:24.05 /0.00 @:0 B@:0
 
 
 **This fix is confirmed to work for the following printers:**
-- Creality Ender-3 Pro v2
+- Creality Ender-3 V2
 - Creality CR-6 SE
 - Creality Ender-3 Pro _(newly produced ones that ship with the new mainboard)_
 - _probably all other Creality printers with the new main board as well_


### PR DESCRIPTION
Had me a bit confused for a few seconds.
There is no Ender-3 Pro v2 :)